### PR TITLE
fix of modal

### DIFF
--- a/templates/pypi/out_model.html
+++ b/templates/pypi/out_model.html
@@ -17,18 +17,23 @@
         <div class="scrollable-section">
           {% for item in last_one_hundred_requests %}
             {% for d in item.json_data_out|sort(attribute='package_name') %}
-              {{d.package_name}}{% if d.has_bracket %}[{{d.bracket_content}}]{%endif%}=={{d.latest_version}} #
-              {% if d.latest_version!=d.current_version %} <strong>From {{d.current_version}}</strong> | {%endif%}
-              {% if d.vulnerabilities|length > 0 %}
-                Vulnerabilities:
-                {% for v in d.vulnerabilities %}
-                  <a href="{{v.link}}" target="_blank">{{v.link}}</a>
-                {% endfor %}
-              {% else %}
-                Vulnerabilities: None
+              {% if loop.index <= 5 %}
+                {{d.package_name}}{% if d.has_bracket %}[{{d.bracket_content}}]{%endif%}=={{d.latest_version}} #
+                {% if d.latest_version!=d.current_version %} <strong>From {{d.current_version}}</strong> | {%endif%}
+                {% if d.vulnerabilities|length > 0 %}
+                  Vulnerabilities:
+                  {% for v in d.vulnerabilities %}
+                    <a href="{{v.link}}" target="_blank">{{v.link}}</a>
+                  {% endfor %}
+                {% else %}
+                  Vulnerabilities: None
+                {% endif %}
+                <br>
               {% endif %}
-              <br>
             {% endfor %}
+            {% if item.json_data_out|length > 5 %}
+              ... (more)
+            {% endif %}
           {% endfor %}
         </div>
       </div>


### PR DESCRIPTION
Title: Fix of Modal Display in Out Model Template

This pull request addresses an issue with the modal display in the `out_model.html` template, where previously all package updates were being displayed without limitation. This could lead to performance issues and user interface clutter when the list of updates was extensive.

The changes introduced in this pull request limit the display to the first five package updates. If more than five updates are available, a "... (more)" message is shown to indicate additional content. This adjustment not only streamlines the user's view by preventing overwhelming amounts of data from being displayed at once but also improves the overall performance of the modal by reducing the amount of data rendered in the DOM.

Additionally, the structure for displaying vulnerabilities and version updates remains intact but is now only applied to the first five entries, making the modal content more manageable and readable.

This fix enhances the user experience by providing a cleaner, more efficient interface for viewing package updates and their associated vulnerabilities.