### PR TITLE
fix of only allowing admin to use ai_fix on view screen

### DIFF
--- a/templates/notes/view.html
+++ b/templates/notes/view.html
@@ -27,11 +27,11 @@
                             <a href="/notes/edit/{{ note.pkid }}" class="btn btn-warning ml-2" title="Edit"><i
                                     class="fa-solid fa-pen-to-square" style="color:black;"></i></a>
                             <a href="/notes/delete/{{ note.pkid }}" class="btn btn-danger ml-2" title="Delete"><i
-                                    class="fa-solid fa-trash" style="color:lightgray;"></i></a>
-                            
+                                    class="fa-solid fa-trash" style="color:lightgray;"></i></a>                                
+                            {% if request.session.is_admin is true %}
                             <a href="/notes/ai-fix/{{note.pkid}}" class="btn btn-success ml-2" title="Send to AI Fix"><i
                                     class="fa-solid fa-robot" style="color:black;"></i></a>
-                 
+                            {%endif%}
                         </div>
                     </div>
                     <!-- /.card-header -->


### PR DESCRIPTION
Title: Fix of Only Allowing Admin to Use AI_Fix on View Screen

This pull request addresses a specific issue where the AI Fix button was accessible to all users on the view note screen. The intended behavior, as per the project requirements, is that only administrators should have the ability to send notes to AI Fix.

In the modifications, a conditional statement has been introduced to render the AI Fix button only when the logged-in user has an admin status. This ensures that the functionality is restricted appropriately, enhancing the security and proper usage of the application features.

By implementing this fix, we ensure that the application adheres to the principle of least privilege, minimizing potential misuse and maintaining system integrity.

Closes #10 