### PR TITLE
removing error when resubmitting

### DIFF
--- a/src/endpoints/users.py
+++ b/src/endpoints/users.py
@@ -153,6 +153,7 @@ async def edit_user_post(
     request: Request,
     user_info: dict = Depends(check_login),
 ):
+    request.session.pop('error-message', None)
     form = await request.form()
 
     user_identifier = user_info["user_identifier"]


### PR DESCRIPTION
Title: Remove Error Message on Resubmission in User Edit Endpoint

This pull request addresses an issue where an error message persisted in the session even after resubmitting a form in the user edit endpoint. By explicitly removing the 'error-message' from the session before handling the form data, we ensure that users will not see outdated error messages if they resubmit the form successfully.

This change improves user experience by preventing confusion caused by lingering error messages and makes the error handling in the application more robust and intuitive.