### PR TITLE
fix: guard against dict results from db_ops causing 500 errors

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,6 +27,7 @@
 	],
 	"postCreateCommand": "pip3 install --upgrade pip setuptools wheel && pip3 install -r requirements/dev.txt && sudo chmod 666 /var/run/docker.sock",
 	// "postStartCommand": "",
+	"remoteUser": "vscode",
 	"customizations": {
 		"vscode": {
 			"settings": {
@@ -52,6 +53,4 @@
 			]
 		}
 	}
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "vscode"
 }

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,20 +1,20 @@
 -r prd.txt
 autoflake==2.3.3 # Vulnerabilities: None
-black==26.5.1 # From 26.3.1 | Vulnerabilities: None
+black==26.5.1 # Vulnerabilities: None
 bump-pydantic==0.8.0 # Vulnerabilities: None
-bumpcalver==2026.7.25.1 # From 2026.3.8.1 | Vulnerabilities: None
+bumpcalver==2026.7.25.1 # Vulnerabilities: None
 calver==2025.10.20 # Vulnerabilities: None
 coverage-badge==1.1.2 # Vulnerabilities: None
 genbadge[all]==1.1.3 # Vulnerabilities: None
 isort==8.0.1 # Vulnerabilities: None
 mkdocs-gen-files==0.6.1 # Vulnerabilities: None
-mkdocs-material==9.7.6 # Vulnerabilities: None
-mkdocstrings[python]==1.0.4 # Vulnerabilities: None
+mkdocs-material==9.7.7 # From 9.7.6 | Vulnerabilities: None
+mkdocstrings[python]==1.0.6 # From 1.0.4 | Vulnerabilities: None
 pre-commit==4.6.1 # Vulnerabilities: None
-pyright==1.1.409 # Vulnerabilities: None
+pyright==1.1.411 # From 1.1.409 | Vulnerabilities: None
 pytest==9.1.1 # Vulnerabilities: None
-pytest-asyncio==1.4.0 # From 1.3.0 | Vulnerabilities: None
+pytest-asyncio==1.4.0 # Vulnerabilities: None
 pytest-cov==7.1.0 # Vulnerabilities: None
 pytest-html==4.2.0 # Vulnerabilities: None
 pytest-xdist==3.8.0 # Vulnerabilities: None
-ruff==0.15.15 # From 0.15.12 | Vulnerabilities: None
+ruff==0.16.2 # From 0.15.15 | Vulnerabilities: None

--- a/requirements/prd.txt
+++ b/requirements/prd.txt
@@ -1,24 +1,24 @@
-alembic==1.18.4 # Vulnerabilities: None
+alembic==1.19.1 # From 1.18.4 | Vulnerabilities: None
 argon2-cffi==25.1.0 # Vulnerabilities: None
 async-lru==2.3.0 # Vulnerabilities: None
-cryptography==48.0.0 # From 47.0.0 | Vulnerabilities: None
-devsetgo-lib[sqlite,postgres]==2026.6.29.3 # Vulnerabilities: None
+cryptography==50.0.0 # From 48.0.0 | Vulnerabilities: None
+devsetgo-lib[sqlite,postgres]==2026.7.23.1 # From 2026.6.29.3 | Vulnerabilities: None
 email-validator==2.3.0 # Vulnerabilities: None
-fastapi[all]==0.138.2 # From 0.136.1 | Vulnerabilities: None
-fastapi-sso==0.21.0 # Vulnerabilities: None
-granian==2.7.8 # From 2.7.4 | Vulnerabilities: None
+fastapi[all]==0.141.1 # From 0.138.2 | Vulnerabilities: None
+fastapi-sso==0.21.1 # From 0.21.0 | Vulnerabilities: None
+granian==2.8.1 # From 2.7.8 | Vulnerabilities: None
 httpx-auth==0.23.1 # Vulnerabilities: None
-Markdown==3.10.2 # Vulnerabilities: None
-nameparser==1.1.3 # Vulnerabilities: None
-ocrmypdf==17.8.1 # From 17.4.2 | Vulnerabilities: None
-openai==2.38.0 # From 2.32.0 | Vulnerabilities: None
-pydantic[email]==2.13.4 # From 2.13.3 | Vulnerabilities: None
-PyJWT[crypto]==2.13.0 # From 2.12.1 | Vulnerabilities: None
+Markdown==3.10.3 # From 3.10.2 | Vulnerabilities: None
+nameparser==2.1.0 # From 1.1.3 | Vulnerabilities: None
+ocrmypdf==17.10.0 # From 17.8.1 | Vulnerabilities: None
+openai==2.53.0 # From 2.38.0 | Vulnerabilities: None
+pydantic[email]==2.13.4 # Vulnerabilities: None
+PyJWT[crypto]==2.13.0 # Vulnerabilities: None
 python-dateutil==2.9.0.post0 # Vulnerabilities: None
-pytz==2026.2 # From 2026.1.post1 | Vulnerabilities: None
-selenium==4.44.0 # From 4.43.0 | Vulnerabilities: None
+pytz==2026.3.post1 # From 2026.2 | Vulnerabilities: None
+selenium==4.46.0 # From 4.44.0 | Vulnerabilities: None
 silly==1.1.0 # Vulnerabilities: None
-starlette-authlib==0.3.20 # From 0.3.17 | Vulnerabilities: None
-tqdm==4.68.3 # Vulnerabilities: None
+starlette-authlib==0.3.20 # Vulnerabilities: None
+tqdm==4.70.0 # From 4.68.3 | Vulnerabilities: None
 unsync==1.4.0 # Vulnerabilities: None
-webdriver-manager==4.1.1 # From 4.0.2 | Vulnerabilities: None
+webdriver-manager==4.1.2 # From 4.1.1 | Vulnerabilities: None

--- a/src/endpoints/admin.py
+++ b/src/endpoints/admin.py
@@ -186,7 +186,9 @@ async def admin_category_edit(
     context = {"categories": None, "rand": secrets.token_urlsafe(2)}
     if category_id is not None:
         query = Select(Categories).where(Categories.pkid == category_id)
-        category = await db_ops.read_one_record(query=query)
+        category = _safe_record(await db_ops.read_one_record(query=query))
+        if category is None:
+            raise HTTPException(status_code=404, detail="Category not found")
         context["category"] = category.to_dict()
 
     logger.debug(f"category-edit: {context}")
@@ -221,10 +223,13 @@ async def add_edit_category(
     if "category_id" in form and form["category_id"] != "":  # no pragma: no cover
         category_id = form["category_id"]
         # Fetch the old data
-        old_data = await db_ops.read_one_record(
-            query=Select(Categories).where(Categories.pkid == category_id)
+        old_data = _safe_record(
+            await db_ops.read_one_record(
+                query=Select(Categories).where(Categories.pkid == category_id)
+            )
         )
-        old_data = old_data.to_dict()
+        if old_data is None:
+            raise HTTPException(status_code=404, detail="Category not found")
 
         updated_data = {
             "name": name,
@@ -236,9 +241,13 @@ async def add_edit_category(
         }
 
         # Update the database
-        data = await db_ops.update_one(
-            table=Categories, record_id=category_id, new_values=updated_data
+        data = _safe_record(
+            await db_ops.update_one(
+                table=Categories, record_id=category_id, new_values=updated_data
+            )
         )
+        if data is None:
+            raise HTTPException(status_code=500, detail="Failed to update category")
         context["category_data"] = data.to_dict()
         context["status"] = "updated"
     else:  # no pragma: no cover
@@ -251,7 +260,9 @@ async def add_edit_category(
             is_system=is_system,
         )
 
-        data = await db_ops.create_one(category_data)
+        data = _safe_record(await db_ops.create_one(category_data))
+        if data is None:
+            raise HTTPException(status_code=500, detail="Failed to create category")
         context["category_data"] = data.to_dict()
         context["status"] = "created"
 

--- a/src/endpoints/blog_posts.py
+++ b/src/endpoints/blog_posts.py
@@ -38,9 +38,25 @@ from ..resources import db_ops, templates
 router = APIRouter()
 
 
+def _safe_list(result) -> list:
+    """Return result when it is a genuine list of ORM objects; empty list otherwise.
+
+    dsg_lib db_ops methods return a plain dict on certain database errors instead
+    of raising an exception, so an isinstance(x, str) guard is not sufficient.
+    """
+    return result if isinstance(result, list) else []
+
+
+def _safe_record(result):
+    """Return result when it is a genuine ORM object; None otherwise."""
+    return result if result is not None and not isinstance(result, dict) else None
+
+
 async def get_user_name(user_id: str):
     query = Select(Users).where(Users.pkid == user_id)
-    user = await db_ops.read_one_record(query=query)
+    user = _safe_record(await db_ops.read_one_record(query=query))
+    if user is None:
+        return "unknown"
     user = user.to_dict()
     full_name = f"{user['first_name']} {user['last_name']}"
     return full_name
@@ -63,8 +79,10 @@ async def list_of_posts(
 
 @router.get("/categories", response_class=JSONResponse)
 async def get_categories():
-    categories = await db_ops.read_query(
-        Select(Categories).where(Categories.is_post).order_by(asc(Categories.name))
+    categories = _safe_list(
+        await db_ops.read_query(
+            Select(Categories).where(Categories.is_post).order_by(asc(Categories.name))
+        )
     )
     try:
         cat_list = [cat.to_dict()["name"] for cat in categories]
@@ -85,7 +103,10 @@ async def delete_post_form(
     query = Select(Posts).where(
         and_(Posts.user_id == user_identifier, Posts.pkid == post_id)
     )
-    post = await db_ops.read_one_record(query=query)
+    post = _safe_record(await db_ops.read_one_record(query=query))
+    if post is None:
+        logger.warning(f"No post found with ID: {post_id} for user: {user_identifier}")
+        return RedirectResponse(url="/posts", status_code=302)
 
     return templates.TemplateResponse(
         request=request, name="/posts/delete.html", context={"post": post}
@@ -104,7 +125,7 @@ async def delete_note(
     query = Select(Posts).where(
         and_(Posts.user_id == user_identifier, Posts.pkid == post_id)
     )
-    post = await db_ops.read_one_record(query=query)
+    post = _safe_record(await db_ops.read_one_record(query=query))
 
     if post is None:
         logger.warning(f"No post found with ID: {post_id} for user: {user_identifier}")
@@ -131,7 +152,7 @@ async def edit_post_form(
     query = Select(Posts).where(
         and_(Posts.user_id == user_identifier, Posts.pkid == post_id)
     )
-    post = await db_ops.read_one_record(query=query)
+    post = _safe_record(await db_ops.read_one_record(query=query))
     if post is None:
         logger.warning(f"No post found with ID: {post_id} for user: {user_identifier}")
         return RedirectResponse(url="/posts", status_code=302)
@@ -172,9 +193,12 @@ async def update_post(
     user_info["timezone"]
 
     # Fetch the old data
-    old_data = await db_ops.read_one_record(
-        query=Select(Posts).where(Posts.pkid == post_id)
+    old_data = _safe_record(
+        await db_ops.read_one_record(query=Select(Posts).where(Posts.pkid == post_id))
     )
+    if old_data is None:
+        logger.warning(f"No post found with ID: {post_id}")
+        return RedirectResponse(url="/posts", status_code=302)
     old_data = old_data.to_dict()
 
     # Get the new data from the form
@@ -199,9 +223,14 @@ async def update_post(
 
     print(f"Updated data: {updated_data}")
     # Update the database
-    data = await db_ops.update_one(
-        table=Posts, record_id=post_id, new_values=updated_data
+    data = _safe_record(
+        await db_ops.update_one(
+            table=Posts, record_id=post_id, new_values=updated_data
+        )
     )
+    if data is None:
+        logger.error(f"Failed to update post with ID: {post_id}")
+        return RedirectResponse(url="/error/500", status_code=303)
     logger.info(f"Updated post with ID: {post_id}")
     # background_tasks.add_task(
     #     notes_metrics.update_notes_metrics, user_id=user_identifier
@@ -382,7 +411,7 @@ async def get_post_id(request: Request, post_id: str):
         user_timezone = "America/New_York"
 
     query = Select(Posts).where(Posts.pkid == post_id)
-    post = await db_ops.read_one_record(query=query)
+    post = _safe_record(await db_ops.read_one_record(query=query))
 
     if post is None:
         logger.warning(f"No post found with ID: {post_id}")

--- a/src/endpoints/notes.py
+++ b/src/endpoints/notes.py
@@ -72,6 +72,21 @@ from ..settings import settings
 router = APIRouter()
 
 
+def _safe_list(result) -> list:
+    """Return result when it is a genuine list of ORM objects; empty list otherwise.
+
+    dsg_lib db_ops methods return a plain dict on certain database errors instead
+    of raising an exception. Guards that only check isinstance(result, str) miss
+    those dict error responses.
+    """
+    return result if isinstance(result, list) else []
+
+
+def _safe_record(result):
+    """Return result when it is a genuine ORM object; None otherwise."""
+    return result if result is not None and not isinstance(result, dict) else None
+
+
 async def process_ai_analysis_background(
     note_id: str, content: str, user_id: str, mood_process: str | None = None
 ):
@@ -132,14 +147,18 @@ async def read_notes(
         logger.debug("User identifier is None, redirecting to login")
         return RedirectResponse(url="/users/login", status_code=302)
 
-    note_metrics = await db_ops.read_one_record(
-        query=Select(NoteMetrics).where(NoteMetrics.user_id == user_identifier)
+    note_metrics = _safe_record(
+        await db_ops.read_one_record(
+            query=Select(NoteMetrics).where(NoteMetrics.user_id == user_identifier)
+        )
     )
 
     if note_metrics is None:
         await notes_metrics.update_notes_metrics(user_id=user_identifier)
-        note_metrics = await db_ops.read_one_record(
-            query=Select(NoteMetrics).where(NoteMetrics.user_id == user_identifier)
+        note_metrics = _safe_record(
+            await db_ops.read_one_record(
+                query=Select(NoteMetrics).where(NoteMetrics.user_id == user_identifier)
+            )
         )
 
     metrics = None
@@ -188,13 +207,25 @@ async def get_note_counts(
     user_identifier = user_info["user_identifier"]
     user_info["timezone"]
 
-    note_metrics = await db_ops.read_one_record(
-        query=Select(NoteMetrics).where(NoteMetrics.user_id == user_identifier)
+    note_metrics = _safe_record(
+        await db_ops.read_one_record(
+            query=Select(NoteMetrics).where(NoteMetrics.user_id == user_identifier)
+        )
     )
     if note_metrics is None:
         await notes_metrics.update_notes_metrics(user_id=user_identifier)
-        note_metrics = await db_ops.read_one_record(
-            query=Select(NoteMetrics).where(NoteMetrics.user_id == user_identifier)
+        note_metrics = _safe_record(
+            await db_ops.read_one_record(
+                query=Select(NoteMetrics).where(NoteMetrics.user_id == user_identifier)
+            )
+        )
+
+    if note_metrics is None:
+        logger.error(f"Unable to load note metrics for user {user_identifier}")
+        return templates.TemplateResponse(
+            request=request,
+            name="/notes/metrics.html",
+            context={"note_metrics": {}},
         )
 
     note_metrics = note_metrics.to_dict()
@@ -221,7 +252,7 @@ async def ai_update_note(
     query = Select(Notes).where(
         and_(Notes.user_id == user_identifier, Notes.pkid == note_id)
     )
-    note = await db_ops.read_one_record(query=query)
+    note = _safe_record(await db_ops.read_one_record(query=query))
 
     if note is None:
         logger.warning(f"No note found with ID: {note_id} for user: {user_identifier}")
@@ -246,7 +277,7 @@ async def ai_fix_processing(
     query = Select(Notes).where(
         and_(Notes.user_id == user_identifier, Notes.pkid == note_id)
     )
-    note = await db_ops.read_one_record(query=query)
+    note = _safe_record(await db_ops.read_one_record(query=query))
     if note is None:
         return RedirectResponse(url="/error/404", status_code=303)
 
@@ -316,7 +347,7 @@ async def edit_note_form(
     query = Select(Notes).where(
         and_(Notes.user_id == user_identifier, Notes.pkid == note_id)
     )
-    note = await db_ops.read_one_record(query=query)
+    note = _safe_record(await db_ops.read_one_record(query=query))
     if note is None:
         logger.warning(f"No note found with ID: {note_id} for user: {user_identifier}")
         return RedirectResponse(url="/notes", status_code=302)
@@ -357,9 +388,12 @@ async def update_note(
     user_info["timezone"]
 
     # Fetch the old data
-    old_data = await db_ops.read_one_record(
-        query=Select(Notes).where(Notes.pkid == note_id)
+    old_data = _safe_record(
+        await db_ops.read_one_record(query=Select(Notes).where(Notes.pkid == note_id))
     )
+    if old_data is None:
+        logger.warning(f"No note found with ID: {note_id} for user: {user_identifier}")
+        return RedirectResponse(url="/notes", status_code=302)
     old_data = old_data.to_dict()
 
     # Get the new data from the form
@@ -383,9 +417,14 @@ async def update_note(
             updated_data[field] = new_value
 
     # Update the database
-    data = await db_ops.update_one(
-        table=Notes, record_id=note_id, new_values=updated_data
+    data = _safe_record(
+        await db_ops.update_one(
+            table=Notes, record_id=note_id, new_values=updated_data
+        )
     )
+    if data is None:
+        logger.error(f"Failed to update note with ID: {note_id}")
+        return RedirectResponse(url="/error/500", status_code=303)
     logger.info(f"Updated note with ID: {note_id}")
     background_tasks.add_task(
         notes_metrics.update_notes_metrics, user_id=user_identifier
@@ -404,7 +443,10 @@ async def delete_note_form(
     query = Select(Notes).where(
         and_(Notes.user_id == user_identifier, Notes.pkid == note_id)
     )
-    note = await db_ops.read_one_record(query=query)
+    note = _safe_record(await db_ops.read_one_record(query=query))
+    if note is None:
+        logger.warning(f"No note found with ID: {note_id} for user: {user_identifier}")
+        return RedirectResponse(url="/notes", status_code=302)
 
     return templates.TemplateResponse(
         request=request, name="/notes/delete.html", context={"note": note}
@@ -424,7 +466,7 @@ async def delete_note(
     query = Select(Notes).where(
         and_(Notes.user_id == user_identifier, Notes.pkid == note_id)
     )
-    note = await db_ops.read_one_record(query=query)
+    note = _safe_record(await db_ops.read_one_record(query=query))
 
     if note is None:
         logger.warning(f"No note found with ID: {note_id} for user: {user_identifier}")
@@ -456,7 +498,7 @@ async def get_note_issue(
         .where(and_(Notes.user_id == user_identifier, Notes.ai_fix))
         .limit(200)
     ).order_by(desc(Notes.date_created))
-    notes = await db_ops.read_query(query=query)
+    notes = _safe_list(await db_ops.read_query(query=query))
 
     # offset date_created and date_updated to user's timezone
     notes = [note.to_dict() for note in notes]
@@ -512,7 +554,10 @@ async def create_note(
         user_id=user_identifier,
         ai_fix=False,  # Will be updated by background task if needed
     )
-    data = await db_ops.create_one(note)
+    data = _safe_record(await db_ops.create_one(note))
+    if data is None:
+        logger.error(f"Failed to create note for user {user_identifier}")
+        return RedirectResponse(url="/error/500", status_code=303)
 
     # Add background tasks for AI analysis and metrics update
     background_tasks.add_task(
@@ -629,7 +674,7 @@ async def read_notes_pagination(
         note_count = await db_ops.count_query(query=query)
         total_pages = -(-note_count // limit) if note_count else 1
         page_notes = await db_ops.read_query(query=query.limit(limit).offset(offset))
-        if isinstance(page_notes, str):
+        if not isinstance(page_notes, list):
             logger.error(f"Unexpected result from read_query: {page_notes}")
             page_notes = []
         notes = [n.to_dict() for n in page_notes]
@@ -638,7 +683,7 @@ async def read_notes_pagination(
         # For ~2,900–5,800 notes Fernet decrypt is fast (~100ms total); the
         # mood/date/tag SQL filters above reduce the set before we get here.
         all_notes = await db_ops.read_query(query=query)
-        if isinstance(all_notes, str):
+        if not isinstance(all_notes, list):
             logger.error(f"Unexpected result from read_query: {all_notes}")
             all_notes = []
         term = search_term.lower()
@@ -747,7 +792,7 @@ async def read_today_notes(
         )
         .order_by(desc(Notes.date_created))
     )
-    notes = await db_ops.read_query(query=query)
+    notes = _safe_list(await db_ops.read_query(query=query))
 
     # offset date_created and date_updated to user's timezone
     notes = [note.to_dict() for note in notes]
@@ -795,7 +840,7 @@ async def read_note(
     query = Select(Notes).where(
         and_(Notes.user_id == user_identifier, Notes.pkid == note_id)
     )
-    note = await db_ops.read_one_record(query=query)
+    note = _safe_record(await db_ops.read_one_record(query=query))
 
     if note is None:
         logger.warning(f"No note found with ID: {note_id} for user: {user_identifier}")

--- a/src/endpoints/notifications.py
+++ b/src/endpoints/notifications.py
@@ -32,6 +32,11 @@ def _is_valid_result(result) -> bool:
     return result is not None and not isinstance(result, dict)
 
 
+def _safe_list(result) -> list:
+    """Return result when it is a genuine list of ORM objects; empty list otherwise."""
+    return result if isinstance(result, list) else []
+
+
 async def _render_item(request: Request, notification_id: str, user_timezone: str, user_identifier: str) -> tuple:
     """Re-fetch a notification (with ownership) and format it for rendering."""
     result = await db_ops.read_one_record(
@@ -63,10 +68,7 @@ async def notifications_partial(
     query = query.limit(50)
 
     results = await db_ops.read_query(query=query)
-    notifications = _format_notifications(
-        results if results and not isinstance(results, str) else [],
-        user_timezone,
-    )
+    notifications = _format_notifications(_safe_list(results), user_timezone)
 
     return templates.TemplateResponse(
         request=request,
@@ -174,9 +176,8 @@ async def clear_all_notifications(
     user_identifier = user_info["user_identifier"]
     query = Select(Notifications).where(Notifications.user_id == user_identifier)
     results = await db_ops.read_query(query=query)
-    if results and not isinstance(results, str):
-        for n in results:
-            await db_ops.delete_one(table=Notifications, record_id=n.pkid)
+    for n in _safe_list(results):
+        await db_ops.delete_one(table=Notifications, record_id=n.pkid)
     logger.info(f"Cleared all notifications for user {user_identifier}")
     return templates.TemplateResponse(
         request=request,

--- a/src/endpoints/users.py
+++ b/src/endpoints/users.py
@@ -52,6 +52,16 @@ from ..settings import settings
 
 router = APIRouter()
 
+
+def _safe_record(result):
+    """Return result when it is a genuine ORM object; None otherwise.
+
+    dsg_lib db_ops methods return a plain dict on certain database errors instead
+    of raising an exception, so a bare `is None` check is not sufficient.
+    """
+    return result if result is not None and not isinstance(result, dict) else None
+
+
 DEFAULT_MOOD_TAKEAWAY_MONTHS = 3
 MIN_MOOD_TAKEAWAY_MONTHS = 1
 MAX_MOOD_TAKEAWAY_MONTHS = 12
@@ -67,7 +77,7 @@ async def edit_user(
     user_info["is_admin"]
 
     query = Select(Users).where(Users.pkid == user_identifier)
-    user = await db_ops.read_one_record(query=query)
+    user = _safe_record(await db_ops.read_one_record(query=query))
 
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
@@ -137,8 +147,10 @@ async def edit_user_post(
         request.session["error-message"] = errors
         return RedirectResponse(url="/users/edit-user", status_code=303)
 
-    current_user = await db_ops.read_one_record(
-        query=Select(Users).where(Users.pkid == user_identifier)
+    current_user = _safe_record(
+        await db_ops.read_one_record(
+            query=Select(Users).where(Users.pkid == user_identifier)
+        )
     )
     current_roles = (current_user.roles or {}) if current_user else {}
     updated_roles = dict(current_roles)
@@ -186,7 +198,7 @@ async def get_user_info(
     user_info["is_admin"]
 
     query = Select(Users).where(Users.pkid == user_identifier)
-    user = await db_ops.read_one_record(query=query)
+    user = _safe_record(await db_ops.read_one_record(query=query))
 
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
@@ -231,8 +243,10 @@ async def github_callback(request: Request):
     async with sso:
         user = await sso.verify_and_process(request)
 
-    user_stored = await db_ops.read_one_record(
-        Select(Users).where(Users.user_name == user.display_name)
+    user_stored = _safe_record(
+        await db_ops.read_one_record(
+            Select(Users).where(Users.user_name == user.display_name)
+        )
     )
 
     if not user_stored:
@@ -255,8 +269,11 @@ async def github_callback(request: Request):
             is_admin=is_admin,
             roles=add_roles,
         )
-        user_stored = await db_ops.create_one(new_user)
+        user_stored = _safe_record(await db_ops.create_one(new_user))
         logger.debug(user_stored)
+
+    if user_stored is None:
+        raise HTTPException(status_code=500, detail="Failed to create or load user")
 
     try:
         user_stored = user_stored.to_dict()

--- a/src/endpoints/web_links.py
+++ b/src/endpoints/web_links.py
@@ -54,6 +54,20 @@ from ..resources import db_ops, templates
 router = APIRouter()
 
 
+def _safe_list(result) -> list:
+    """Return result when it is a genuine list of ORM objects; empty list otherwise.
+
+    dsg_lib db_ops methods return a plain dict on certain database errors instead
+    of raising an exception, so an isinstance(x, str) guard is not sufficient.
+    """
+    return result if isinstance(result, list) else []
+
+
+def _safe_record(result):
+    """Return result when it is a genuine ORM object; None otherwise."""
+    return result if result is not None and not isinstance(result, dict) else None
+
+
 # api endpoints
 # /list with filters (by tag, by date range, by category)
 @router.get("/")
@@ -116,10 +130,12 @@ async def bulk_weblink(
 
 @router.get("/categories", response_class=JSONResponse)
 async def get_categories():
-    categories = await db_ops.read_query(
-        Select(Categories)
-        .where(Categories.is_weblink)
-        .order_by(asc(func.lower(Categories.name)))
+    categories = _safe_list(
+        await db_ops.read_query(
+            Select(Categories)
+            .where(Categories.is_weblink)
+            .order_by(asc(func.lower(Categories.name)))
+        )
     )
     cat_list = [cat.to_dict()["name"] for cat in categories]
     return cat_list
@@ -173,7 +189,7 @@ async def read_weblinks_pagination(
     query = query.order_by(WebLinks.date_created.desc()).limit(limit).offset(offset)
     weblinks = await db_ops.read_query(query=query)
     logger.debug(f"weblinks returned from pagination query {weblinks}")
-    if isinstance(weblinks, str):
+    if not isinstance(weblinks, list):
         logger.error(f"Unexpected result from read_query: {weblinks}")
         weblinks = []
     else:
@@ -298,9 +314,13 @@ async def view_weblink(
     if user_timezone is None:
         user_timezone = "America/New_York"
 
-    link_obj = await db_ops.read_one_record(
-        Select(WebLinks).where(WebLinks.pkid == pkid)
+    link_obj = _safe_record(
+        await db_ops.read_one_record(Select(WebLinks).where(WebLinks.pkid == pkid))
     )
+
+    if link_obj is None:
+        logger.warning(f"No weblink found with ID: {pkid}")
+        return RedirectResponse(url="/error/404", status_code=303)
 
     # Store the is_youtube property before converting to dict
     link_is_youtube = link_obj.is_youtube
@@ -357,7 +377,12 @@ async def edit_weblink(
 ):
     # user_identifier = user_info["user_identifier"]
 
-    data = await db_ops.read_one_record(Select(WebLinks).where(WebLinks.pkid == pkid))
+    data = _safe_record(
+        await db_ops.read_one_record(Select(WebLinks).where(WebLinks.pkid == pkid))
+    )
+    if data is None:
+        logger.warning(f"No weblink found with ID: {pkid}")
+        return RedirectResponse(url="/error/404", status_code=302)
 
     data = data.to_dict()
 
@@ -400,13 +425,20 @@ async def get_update_comment(
 ):
     user_info["user_identifier"]
 
-    link = await db_ops.read_one_record(Select(WebLinks).where(WebLinks.pkid == pkid))
+    link = _safe_record(
+        await db_ops.read_one_record(Select(WebLinks).where(WebLinks.pkid == pkid))
+    )
+    if link is None:
+        logger.warning(f"No weblink found with ID: {pkid}")
+        return RedirectResponse(url="/error/404", status_code=302)
 
     # Get categories for the dropdown
-    categories = await db_ops.read_query(
-        Select(Categories)
-        .where(Categories.is_weblink)
-        .order_by(asc(func.lower(Categories.name)))
+    categories = _safe_list(
+        await db_ops.read_query(
+            Select(Categories)
+            .where(Categories.is_weblink)
+            .order_by(asc(func.lower(Categories.name)))
+        )
     )
     cat_list = [cat.to_dict()["name"] for cat in categories]
 
@@ -468,7 +500,9 @@ async def delete_weblink_form(
     user_identifier = user_info["user_identifier"]
 
     # Check if the weblink exists and belongs to the user
-    link = await db_ops.read_one_record(Select(WebLinks).where(WebLinks.pkid == pkid))
+    link = _safe_record(
+        await db_ops.read_one_record(Select(WebLinks).where(WebLinks.pkid == pkid))
+    )
 
     if link is None:
         logger.warning(f"No weblink found with ID: {pkid}")
@@ -509,7 +543,9 @@ async def delete_weblink(
         return RedirectResponse(url="/error/400", status_code=302)
 
     # Check if the weblink exists and belongs to the user
-    link = await db_ops.read_one_record(Select(WebLinks).where(WebLinks.pkid == pkid))
+    link = _safe_record(
+        await db_ops.read_one_record(Select(WebLinks).where(WebLinks.pkid == pkid))
+    )
 
     if link is None:
         logger.warning(f"No weblink found with ID: {pkid} for user: {user_identifier}")


### PR DESCRIPTION
dsg_lib db_ops read/create/update methods can return a plain dict on certain database errors instead of raising or returning None/list, which crashed downstream .to_dict()/attribute access (e.g. 'dict' object has no attribute 'user_id' in the admin section). Added _safe_record/_safe_list guards across admin, blog_posts, notes, notifications, users, and web_links endpoints, with proper 404/error handling when a record is missing or malformed.

Also fixes devcontainer running as root (added remoteUser: vscode) and bumps pinned dependency versions.